### PR TITLE
Don't show NavigationBar in FullScreen mode

### DIFF
--- a/qml/BrowserWebView.qml
+++ b/qml/BrowserWebView.qml
@@ -31,13 +31,12 @@ LunaWebEngineView {
     profile.httpUserAgent: userAgent.defaultUA
 
     onFullScreenRequested: {
-        if (request.toggleOn)
+        if (request.toggleOn) {
             navigationBar.visible = false;
-            //Window.showFullScreen()
-        else
-            //Window.showNormal()
+        } else {
             navigationBar.visible = true;
-        request.accept()
+        }
+        request.accept();
     }
 
     visible: true

--- a/qml/NavigationBar.qml
+++ b/qml/NavigationBar.qml
@@ -43,7 +43,7 @@ Rectangle {
 
     property bool initialSelection: true
     width: parent.width
-    height: Units.gu(5.2)
+    height: visible ? Units.gu(5.2) : Units.gu(0)
     color: "#343434"
 
     Component.onCompleted: navigationBar.__getDefaultSearch()


### PR DESCRIPTION
When in FullScreen we don't show the NavigationBar, but it's height is
still being taken up by a white area. By setting the heigth only when
NavigationBar is visible this is solved.

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>